### PR TITLE
CSS selector extensions

### DIFF
--- a/cssselect2/compiler.py
+++ b/cssselect2/compiler.py
@@ -128,9 +128,9 @@ def _compile_node(selector, extensions):
             return '(%s) and (%s)' % (right, left)
 
     elif isinstance(selector, parser.CompoundSelector):
-        sub_expressions = filter(lambda x: x != '1',
-                                 [_compile_node(sel, extensions) for sel in
-                                  selector.simple_selectors])
+        sub_expressions = [csel for csel in [
+                           _compile_node(sel, extensions) for sel in
+                           selector.simple_selectors] if csel != '1']
         if len(sub_expressions) == 1:
             test = sub_expressions[0]
         elif '0' in sub_expressions:

--- a/cssselect2/compiler.py
+++ b/cssselect2/compiler.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import re
 
 from tinycss2.nth import parse_nth
-from tinycss2 import serialize
 from webencodings import ascii_lower
 
 from . import parser
@@ -42,12 +41,17 @@ def compile_selector_list(input, namespaces=None):
 
 class CompiledSelector(object):
     def __init__(self, parsed_selector):
-        source = _compile_node(parsed_selector.parsed_tree)
+        node = parsed_selector.parsed_tree
+        source = _compile_node(node, parsed_selector.extensions)
         self.never_matches = source == '0'
+        eval_mods = {'split_whitespace': split_whitespace,
+                     'ascii_lower': ascii_lower}
+        for ext_type in parsed_selector.extensions.values():
+            for ext in ext_type.values():
+                if 'modules' in ext:
+                    eval_mods.update(ext['modules'])
         self.test = eval(
-            'lambda el: ' + source,
-            {'split_whitespace': split_whitespace,
-                'ascii_lower': ascii_lower, 're': re},
+            'lambda el: ' + source, eval_mods,
             {},
         )
         self.specificity = parsed_selector.specificity
@@ -58,7 +62,6 @@ class CompiledSelector(object):
         self.lower_local_name = None
         self.namespace = None
 
-        node = parsed_selector.parsed_tree
         if isinstance(node, parser.CombinedSelector):
             node = node.right
         for simple_selector in node.simple_selectors:
@@ -73,7 +76,7 @@ class CompiledSelector(object):
                 self.namespace = simple_selector.namespace
 
 
-def _compile_node(selector):
+def _compile_node(selector, extensions):
     """Return a boolean expression, as a Python source string.
 
     When evaluated in a context where the `el` variable is an
@@ -88,7 +91,7 @@ def _compile_node(selector):
     # 1 and 0 are used for True and False to avoid global lookups.
 
     if isinstance(selector, parser.CombinedSelector):
-        left_inside = _compile_node(selector.left)
+        left_inside = _compile_node(selector.left, extensions)
         if left_inside == '0':
             return '0'  # 0 and x == 0
         elif left_inside == '1':
@@ -115,7 +118,7 @@ def _compile_node(selector):
         else:
             raise SelectorError('Unknown combinator', selector.combinator)
 
-        right = _compile_node(selector.right)
+        right = _compile_node(selector.right, extensions)
         if right == '0':
             return '0'  # 0 and x == 0
         elif right == '1':
@@ -125,9 +128,9 @@ def _compile_node(selector):
             return '(%s) and (%s)' % (right, left)
 
     elif isinstance(selector, parser.CompoundSelector):
-        sub_expressions = [
-            expr for expr in map(_compile_node, selector.simple_selectors)
-            if expr != '1']
+        sub_expressions = filter(lambda x: x != '1',
+                                 [_compile_node(sel, extensions) for sel in
+                                  selector.simple_selectors])
         if len(sub_expressions) == 1:
             test = sub_expressions[0]
         elif '0' in sub_expressions:
@@ -267,6 +270,10 @@ def _compile_node(selector):
                     '    for i, s in enumerate(el.etree_siblings))')
         elif selector.name == 'empty':
             return 'not (el.etree_children or el.etree_element.text)'
+        elif ('pseudoClass' in extensions and
+              selector.name in extensions['pseudoClass']):
+            callback = extensions['pseudoClass'][selector.name]['callback']
+            return callback(selector)
         else:
             raise SelectorError('Unknown pseudo-class', selector.name)
 
@@ -315,10 +322,10 @@ def _compile_node(selector):
                         '     for n, r in [divmod(%s - %i, %i)])'
                         % (count, B, a))
 
-        elif selector.name == 'match':
-            regex = serialize(selector.arguments)
-            return ('re.search("%s", el.textstring())'
-                    ' is not None' % regex)
+        elif ('pseudoClass' in extensions and
+              selector.name in extensions['pseudoClass']):
+            callback = extensions['pseudoClass'][selector.name]['callback']
+            return callback(selector)
         else:
             raise SelectorError('Unknown functional pseudo-class',
                                 selector.name)

--- a/cssselect2/extensions.py
+++ b/cssselect2/extensions.py
@@ -1,0 +1,18 @@
+# coding: utf8
+
+from tinycss2 import serialize
+import re
+
+
+def _match(selector):
+    "Callback for match pseudoClass."
+    regex = serialize(selector.arguments)
+    return ('(re.search("%s", el.textstring()) is not None)' % regex)
+
+extensions = {'pseudoClass': {'match': {'callback': _match,
+                                        'modules': {'re': re}
+                                        },
+                              'pass': {'callback': lambda s: '1'},
+                              'deferred': {'callback': lambda s: '1'},
+                              }
+              }

--- a/cssselect2/parser.py
+++ b/cssselect2/parser.py
@@ -20,7 +20,7 @@ from ._compat import basestring
 __all__ = ['parse']
 
 
-def parse(input, namespaces=None):
+def parse(input, namespaces=None, extensions=None):
     """
     :param input:
         A :term:`string`, or an iterable of :term:`component values`.
@@ -29,33 +29,34 @@ def parse(input, namespaces=None):
         input = parse_component_value_list(input)
     tokens = TokenStream(input)
     namespaces = namespaces or {}
-    yield parse_selector(tokens, namespaces)
+    extensions = extensions or {}
+    yield parse_selector(tokens, namespaces, extensions)
     while 1:
         next = tokens.next()
         if next is None:
             return
         elif next == ',':
-            yield parse_selector(tokens, namespaces)
+            yield parse_selector(tokens, namespaces, extensions)
         else:
             raise SelectorError(next, 'unpexpected %s token.' % next.type)
 
 
-def parse_selector(tokens, namespaces):
+def parse_selector(tokens, namespaces, extensions):
     result, pseudo_element = parse_compound_selector(tokens, namespaces)
     while 1:
         has_whitespace = tokens.skip_whitespace()
         if pseudo_element is not None:
-            return Selector(result, pseudo_element)
+            return Selector(result, pseudo_element, extensions)
         peek = tokens.peek()
         if peek is None or peek == ',':
-            return Selector(result, pseudo_element)
+            return Selector(result, pseudo_element, extensions)
         elif peek in ('>', '+', '~'):
             combinator = peek.value
             tokens.next()
         elif has_whitespace:
             combinator = ' '
         else:
-            return Selector(result, pseudo_element)
+            return Selector(result, pseudo_element, extensions)
         compound, pseudo_element = parse_compound_selector(tokens, namespaces)
         result = CombinedSelector(result, combinator, compound)
 
@@ -270,8 +271,9 @@ class TokenStream(object):
 
 
 class Selector(object):
-    def __init__(self, tree, pseudo_element=None):
+    def __init__(self, tree, pseudo_element=None, extensions=None):
         self.parsed_tree = tree
+        self.extensions = extensions
         if pseudo_element is None:
             self.pseudo_element = pseudo_element
             #: Tuple of 3 integers: http://www.w3.org/TR/selectors/#specificity

--- a/cssselect2/tests.py
+++ b/cssselect2/tests.py
@@ -268,8 +268,77 @@ def test_select_shakespeare():
     assert count('div[class|=dialog]') == 50 # ? Seems right
 #    assert count('div[class!=madeup]') == 243 # ? Seems right
     assert count('div[class~=dialog]') == 51 # ? Seems right
+
+
+def test_select_extensions():
+    document = etree.fromstring(HTML_SHAKESPEARE)
+    body = document.find('.//{http://www.w3.org/1999/xhtml}body')
+    body = ElementWrapper.from_xml_root(body)
+
+    from .extensions import extensions
+    from .parser import parse
+    from .compiler import CompiledSelector
+
+    def count(selector):
+        sels = [CompiledSelector(s) for s in parse(selector, {}, extensions)]
+        return sum(1 for _ in body.query_all(*sels))
+
+    # Data borrowed from http://mootools.net/slickspeed/
+
+    ## Changed from original; probably because I'm only
+    ## searching the body.
+    #assert count('*') == 252
+    assert count('*') == 246
+#    assert count('div:contains(CELIA)') == 26
+    assert count('div:only-child') == 22 # ?
+    assert count('div:nth-child(even)') == 106
+    assert count('div:nth-child(2n)') == 106
+    assert count('div:nth-child(odd)') == 137
+    assert count('div:nth-child(2n+1)') == 137
+    assert count('div:nth-child(n)') == 243
+    assert count('div:last-child') == 53
+    assert count('div:first-child') == 51
+    assert count('div > div') == 242
+    assert count('div + div') == 190
+    assert count('div ~ div') == 190
+    assert count('body') == 1
+    assert count('body div') == 243
+    assert count('div') == 243
+    assert count('div div') == 242
+    assert count('div div div') == 241
+    assert count('div, div, div') == 243
+    assert count('div, a, span') == 243
+    assert count('.dialog') == 51
+    assert count('div.dialog') == 51
+    assert count('div .dialog') == 51
+    assert count('div.character, div.dialog') == 99
+    assert count('div.direction.dialog') == 0
+    assert count('div.dialog.direction') == 0
+    assert count('div.dialog.scene') == 1
+    assert count('div.scene.scene') == 1
+    assert count('div.scene .scene') == 0
+    assert count('div.direction .dialog ') == 0
+    assert count('div .dialog .direction') == 4
+    assert count('div.dialog .dialog .direction') == 4
+    assert count('#speech5') == 1
+    assert count('div#speech5') == 1
+    assert count('div #speech5') == 1
+    assert count('div.scene div.dialog') == 49
+    assert count('div#scene1 div.dialog div') == 142
+    assert count('#scene1 #speech1') == 1
+    assert count('div[class]') == 103
+    assert count('div[class=dialog]') == 50
+    assert count('div[class^=dia]') == 51
+    assert count('div[class$=log]') == 50
+    assert count('div[class*=sce]') == 1
+    assert count('div[class|=dialog]') == 50 # ? Seems right
+#    assert count('div[class!=madeup]') == 243 # ? Seems right
+    assert count('div[class~=dialog]') == 51 # ? Seems right
     assert count('div:match(CELIA)') == 26
     assert count('div:match(^CELIA)') == 21
+    assert count('body:pass(1)') == 1
+    assert count('body:pass(2)') == 1
+    assert count('body:deferred') == 1
 
 HTML_IDS = '''
 <html id="html" xmlns="http://www.w3.org/1999/xhtml"><head>


### PR DESCRIPTION
Put in place hooks for CSS syntax extensions. Use the hooks to implement `match` and `pass` and `deferred` as extensions. Missing docs on exactly _how_ to write extensions (what does the call back function do, what are modules for, etc.), however `match` provides a complete example.
