### PR TITLE
Allow match regex to be received string-wrapped

### DIFF
--- a/cssselect2/extensions.py
+++ b/cssselect2/extensions.py
@@ -7,7 +7,8 @@ import re
 def _match(selector):
     "Callback for match pseudoClass."
     regex = serialize(selector.arguments)
-    if (regex.startswith('"') and regex.endswith('"')) or (regex.startswith("'") and regex.endswith("'")):
+    trim = '\"\''
+    if regex[0] in trim and regex[0] == regex[-1]:
       regex = regex[1:-1]
     return ('(re.search("%s", el.textstring()) is not None)' % regex)
 

--- a/cssselect2/extensions.py
+++ b/cssselect2/extensions.py
@@ -7,7 +7,7 @@ import re
 def _match(selector):
     "Callback for match pseudoClass."
     regex = serialize(selector.arguments)
-    if (regex.startswith('"') and regex.endswith('"')) or (regex.startswith("'") and regex.endswith(";")):
+    if (regex.startswith('"') and regex.endswith('"')) or (regex.startswith("'") and regex.endswith("'")):
       regex = regex[1:-1]
     return ('(re.search("%s", el.textstring()) is not None)' % regex)
 

--- a/cssselect2/extensions.py
+++ b/cssselect2/extensions.py
@@ -7,7 +7,7 @@ import re
 def _match(selector):
     "Callback for match pseudoClass."
     regex = serialize(selector.arguments)
-    if regex.startswith('"') and regex.endswith('"'):
+    if (regex.startswith('"') and regex.endswith('"')) or (regex.startswith("'") and regex.endswith(";")):
       regex = regex[1:-1]
     return ('(re.search("%s", el.textstring()) is not None)' % regex)
 

--- a/cssselect2/extensions.py
+++ b/cssselect2/extensions.py
@@ -7,6 +7,8 @@ import re
 def _match(selector):
     "Callback for match pseudoClass."
     regex = serialize(selector.arguments)
+    if regex.startswith('"') and regex.endswith('"'):
+      regex = regex[1:-1]
     return ('(re.search("%s", el.textstring()) is not None)' % regex)
 
 extensions = {'pseudoClass': {'match': {'callback': _match,


### PR DESCRIPTION
Strip a single set of quotes around the regex if it was received wrapped in a string. Will allow for usage such as :match("^[a-zA-Z]")  as well as the original usage :match(^[a-zA-Z])
