### PR TITLE
support the `:has` selector for checking descendants

### DIFF
--- a/cssselect2/compiler.py
+++ b/cssselect2/compiler.py
@@ -147,6 +147,10 @@ def _compile_node(selector, extensions):
                 return '0'
             else:
                 return 'not (%s)' % test
+
+        elif isinstance(selector, parser.HasSelector):
+            return 'any((%s) for el in el.iter_subtree())' % test
+
         else:
             return test
 

--- a/cssselect2/parser.py
+++ b/cssselect2/parser.py
@@ -133,6 +133,8 @@ def parse_simple_selector(tokens, namespaces, in_negation=False):
                 if in_negation:
                     raise SelectorError(next, 'nested :not()')
                 return parse_negation(next, namespaces), None
+            elif name == 'has':
+                return parse_has(next, namespaces), None
             else:
                 return FunctionalPseudoClassSelector(name,
                                                      next.arguments), None
@@ -156,6 +158,17 @@ def parse_negation(negation_token, namespaces):
     else:
         raise SelectorError(
             negation_token, ':not() only accepts a simple selector')
+
+
+def parse_has(has_token, namespaces):
+    tokens = TokenStream(has_token.arguments)
+    selector = parse_selector(tokens, namespaces, {})
+    tokens.skip_whitespace()
+    if tokens.next() is None:
+        return HasSelector([selector.parsed_tree])
+    else:
+        raise SelectorError(
+            has_token, ':has() is apparently still buggy. It should accept any selector')
 
 
 def parse_attribute_selector(tokens, namespaces):
@@ -414,3 +427,7 @@ class FunctionalPseudoClassSelector(object):
 class NegationSelector(CompoundSelector):
     def __repr__(self):
         return ':not(%r)' % CompoundSelector.__repr__(self)
+
+class HasSelector(CompoundSelector):
+    def __repr__(self):
+        return ':has(%r)' % CompoundSelector.__repr__(self)

--- a/cssselect2/tests.py
+++ b/cssselect2/tests.py
@@ -208,6 +208,15 @@ def test_select():
     assert pcss(':checked') == [
         'checkbox-checked', 'checkbox-disabled-checked']
 
+    # Check the "has" selector
+    assert pcss(':has(a > foobar)') == []
+    assert pcss('ol:has(li)') == ['first-ol']
+    assert pcss('ol:has(li > div)') == ['first-ol']
+    assert pcss('ol:has(li div)') == ['first-ol']
+    assert pcss(':not(:has(a > foobar))') == all_ids
+    assert pcss('ol:has(div)') == ['first-ol']
+    # assert pcss('ol:has(> li)') == ['first-ol']
+
 
 def test_select_shakespeare():
     document = etree.fromstring(HTML_SHAKESPEARE)


### PR DESCRIPTION
(refs https://github.com/Connexions/cnx-recipes/pull/85 )

Allows for selector fanciness like `.exercise:has(.solution)` (from [sizzle](https://sizzlejs.com/)) rather than having to encode temporary data into the DOM via multiple passes (ie [cnx-recipes#85](https://github.com/Connexions/cnx-recipes/pull/85/files#diff-5503849fa0b906e2868f1793f3f36daaR6) ).

Currently, this is sprinkled around in [multiple passes](https://github.com/Connexions/cnx-recipes/blob/master/books/rulesets/common/_utils.scss#L47-L69) (is very confusing to know where this is used) and an additional `os-hasSolutions` class is added to exercises. There are probably other places where this would be useful 😄 

Occurrences that could be removed if this is added: [search results for hasSolutions](https://github.com/Connexions/cnx-recipes/search?utf8=%E2%9C%93&q=hasSolutions)

/cc @helenemccarron @reedstrm 

(wow, that took **a lot** of debugging to get a couple lines of code; my python is rusty and the `eval` solution, while "cute" is a pain to debug & figure out what's going on 😄 )
