### PR TITLE
Remove CSS escape characters from pseudo arg if unquoted

### DIFF
--- a/cssselect2/extensions.py
+++ b/cssselect2/extensions.py
@@ -9,7 +9,7 @@ from . import ext_utils as ex
 
 def _match(selector):
     "Callback for match pseudoClass."
-    regex = serialize(selector.arguments)
+    regex = re.sub(r'(?<!\\)[\\]', '', serialize(selector.arguments))
     trim = '\"\''
     if regex[0] in trim and regex[0] == regex[-1]:
         regex = regex[1:-1]

--- a/cssselect2/extensions.py
+++ b/cssselect2/extensions.py
@@ -9,10 +9,12 @@ from . import ext_utils as ex
 
 def _match(selector):
     "Callback for match pseudoClass."
-    regex = re.sub(r'(?<!\\)[\\]', '', serialize(selector.arguments))
+    regex = serialize(selector.arguments)
     trim = '\"\''
     if regex[0] in trim and regex[0] == regex[-1]:
         regex = regex[1:-1]
+    else:
+        regex = re.sub(r'(?<!\\)[\\]', '', regex)
     return ('(re.search("%s", ex.textstring(el)) is not None)' % regex)
 
 


### PR DESCRIPTION
We were hoping for this behavior so that we can keep our Sass updated to the latest version, which can't handle the quoted strings that we passed through the `:match` pseudo-class. Instead Sass expects something passing as a selector. We can do this by using CSS escape characters in an unquoted argument but they must be removed before the argument is used as a regular expression.