### PR TITLE
Give it a name we can release under

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 cssselect2: CSS selectors for Python ElementTree
 ################################################
 
+Fork of ``cssselect2`` by Simon Sapin.
+
 cssselect2 is a straightforward implementation of `CSS3 Selectors`_ for markup
 documents (HTML, XML, etc.) that can be read by `ElementTree`_-like parsers
 (including cElementTree, lxml_, html5lib_, etc.)

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,13 @@ needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 setup(
-    name='cssselect2',
+    name='cnx-cssselect2',
     version=VERSION,
-    author='Simon Sapin',
-    author_email='simon.sapin@exyr.org',
+    author='OpenStax CNX',
+    author_email='info@cnx.org',
     description='CSS selectors for Python ElementTree',
     long_description=README,
-    url='http://packages.python.org/cssselect2/',
+    url='https://github.com/connexions/cnx-cssselect2',
     license='BSD',
     packages=['cssselect2'],
     package_data={'cssselect2': ['tests/*']},


### PR DESCRIPTION
This problem with the naming collision is reoccurring and often times leads to long debug cycles because it's not clear we have the wrong version. Thus, I propose we name this thing and own it! (wipes hands) Problem solved. 😉 